### PR TITLE
46 backend   event creation   create database to hold list of timezones

### DIFF
--- a/back-end/changemate_proj/urls.py
+++ b/back-end/changemate_proj/urls.py
@@ -24,7 +24,7 @@ from django.urls import re_path
 from rest_framework import permissions
 from drf_yasg.views import get_schema_view
 from drf_yasg import openapi
-
+from .views import get_timezones
 
 # test connection
 def connection_test(request):
@@ -54,6 +54,7 @@ urlpatterns = [
     path("swagger<format>/", schema_view.without_ui(cache_timeout=0), name="schema-json"),
     path("swagger/", schema_view.with_ui("swagger", cache_timeout=0), name="schema-swagger-ui"),
     path("redoc/", schema_view.with_ui("redoc", cache_timeout=0), name="schema-redoc"),
+    path("api/v1/timezones/", get_timezones, name="timezones")
 ]
 
 urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/back-end/changemate_proj/views.py
+++ b/back-end/changemate_proj/views.py
@@ -1,0 +1,8 @@
+from django.http import JsonResponse
+import pytz
+
+def get_timezones(request):
+    '''get most common timezones in reverse order so US timezones are listed first'''
+    timezones = pytz.common_timezones
+    timezones.reverse()
+    return JsonResponse({'timezones': timezones}, safe=False)

--- a/back-end/event_app/views.py
+++ b/back-end/event_app/views.py
@@ -193,3 +193,6 @@ class DefautlEventIcon(APIView):
             icon_url = json_response.get('icon').get("thumbnail_url")
             return Response(icon_url)
         return Response("This parameter doesn't exist within the noun project")
+     
+
+     


### PR DESCRIPTION
Created an api endpoint to pull most common timezones listing US timezones first.

cannot get it to list on swagger for some reason but the the call is

http://127.0.0.1:8000/api/v1/timezones/

![image](https://github.com/crystaljobe/change-mate/assets/142848456/440e6d37-ae5b-4e71-98bf-9f7ed5ab2466)
