### PR TITLE
added condition to run search start_date if no end_date present

### DIFF
--- a/back-end/event_app/views.py
+++ b/back-end/event_app/views.py
@@ -59,7 +59,7 @@ class EventsView(TokenReq):
         if start_date and end_date:
             queryset = events.filter(event_start__date__range=[start_date, end_date])
         #if no end date given search only for dates on start date
-        if start_date:
+        if start_date and not end_date:
             queryset = events.filter(event_start__date=start_date)
         # case-insensitive partial match for filtering for location
         if location:


### PR DESCRIPTION
Added extra condition to only run search by date if end date is not provided.

<img width="438" alt="image" src="https://github.com/crystaljobe/change-mate/assets/142848456/437b37b5-e49b-4ef6-b282-37c9dd954a62">
