### PR TITLE
removed string filters from photo url - photos render properly now

### DIFF
--- a/front-end/src/pages/CreateEvent.jsx
+++ b/front-end/src/pages/CreateEvent.jsx
@@ -82,11 +82,8 @@ export default function CreateEvent() {
       const reader = new FileReader();
       reader.onloadend = () => {
         // Ensures it is a valid base64 format for the image
-        const base64String = reader.result
-          .replace("data:", "")
-          .replace(/^.+,/, "");
         setPhotoPreview(reader.result);
-        setEventPhoto(base64String);
+        setEventPhoto(reader.result);
       };
       reader.readAsDataURL(file);
     }


### PR DESCRIPTION
<img width="415" alt="image" src="https://github.com/crystaljobe/change-mate/assets/142848456/6efe4920-9181-49e4-abc6-215321424a6a">

removing the .replace lines fixed the photo rendering problem.