### PR TITLE
 BUG - location dropdown falling behind filter buttons #254

### DIFF
--- a/front-end/src/components/MapboxGeocoderComponent.jsx
+++ b/front-end/src/components/MapboxGeocoderComponent.jsx
@@ -12,6 +12,7 @@ const MapboxGeocoderComponent = ({setCoords}) => {
       accessToken: "pk.eyJ1IjoiY3J5c3RhbGpvYmUiLCJhIjoiY2x2Y3VkMzFxMG13ZzJrcGY5dDB0bGJvYyJ9.PV_ZgI2EhyhNfcRHmp2OPw",
       types: 'country,region,place,postcode,locality,neighborhood',
       placeholder: "address, city, state",
+      limit: 3,
     });
 
     // Add geocoder to the specified container


### PR DESCRIPTION
fixed location search on search page to not have suggestions rendering behind the filters
![Mapbox-dropdown-fixed](https://github.com/crystaljobe/change-mate/assets/141180011/dfe681ea-7e3c-4ff0-a30d-4d3bc700ef3b)
